### PR TITLE
minor doc tweak

### DIFF
--- a/docs/symbols/comb.html
+++ b/docs/symbols/comb.html
@@ -979,14 +979,15 @@ var MyObject = comb.define(null, {
 });
 
 //NOTE: this will not work properly for native objects like Date.
-var createNewMyObject = function(){
-   try {
-     p = new MyObject();
+var createNewMyObject = function () {
+    try {
+        var p = new MyObject();
     } catch (ignore) {
-         //ignore the error because its probably from missing arguments
+        //ignore the error because its probably from missing arguments
     }
     //Now lets take care of arguments supplied!!!
-    return MyObject.apply(p, comb.argsToArray(arguments));
+    MyObject.apply(p, comb.array.flatten(["called by function wrapper"], comb.argsToArray(arguments)));
+    return p;
 };
 
 //This example creates an object with a world property but its not a function!


### PR DESCRIPTION
Original example was throwing an error:

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
TypeError: Cannot read property 'hello' of undefined
    at Object.<anonymous> (/home/pete/ctest.js:31:2)
    at Module._compile (module.js:441:26)
    at Object..js (module.js:459:10)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:479:10)
    at EventEmitter._tickCallback (node.js:192:40)

```
