### PR TITLE
Modify chain() to propagate errors to next link by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BENCHMARKS = `find benchmark -name *.benchmark.js `
 DOC_COMMAND=coddoc -f multi-html -d ./lib --dir ./docs
 
 test:
-	export NODE_PATH=$NODE_PATH:lib && ./node_modules/it/bin/it -r dotmatrix
+	export NODE_PATH=${NODE_PATH}:lib && ./node_modules/it/bin/it -r dotmatrix
 
 test-coverage:
 	rm -rf ./lib-cov && node-jscoverage ./lib ./lib-cov && export NODE_PATH=$NODE_PATH:lib-cov && ./node_modules/it/bin/it -r dotmatrix

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -225,7 +225,14 @@ var Promise = define(null, {
             this.addCallback(function (results) {
                 callback.call(this, results).then(promise);
             });
+
+            // If no errback passed, then invoke our promise's errback to pass
+            // on to next link in the chain.
+            errback = errback || function (err) {
+                promise.errback(err);
+            };
             this.addErrback(errback);
+
             return promise;
         },
 
@@ -238,11 +245,15 @@ var Promise = define(null, {
          *
          */
         chainBoth:function (callback) {
-            var p = this.chain(callback);
-            this.addErrback(function (results) {
-                callback.call(this, results).then(p);
+            var promise = new Promise();
+            this.addCallback(function (results) {
+                callback.call(this, results).then(promise);
             });
-            return p;
+
+            this.addErrback(function (results) {
+                callback.call(this, results).then(promise);
+            });
+            return promise;
         }
 
 

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -256,6 +256,32 @@ it.describe("comb.Promise", function (it) {
 
         });
 
+        it.should("propagate errors if no errback ", function (next) {
+            var promise = new Promise();
+            promise.chain(
+                function (res) {
+                    var promise2 = new Promise();
+                    process.nextTick(comb.hitch(promise2, "callback", res + " world"), 1000);
+                    return promise2;
+                }).chain(
+                function (res) {
+                    var promise3 = new Promise();
+                    process.nextTick(comb.hitch(promise3, "errback", "error in 3"), 1000);
+                    return promise3;
+                }).chain(
+                function (res) {
+                    var promise4 = new Promise();
+                    process.nextTick(comb.hitch(promise4, "callback", res + " not called"), 1000);
+                    return promise4;
+                })
+                .then(next, function (res) {
+                    assert.equal(res, "error in 3")
+                    next();
+                });
+            setTimeout(comb.hitch(promise, "callback", "hello"), 1000);
+
+        });
+
     });
 
     it.describe("Promise#chainBoth", function (it) {
@@ -293,6 +319,7 @@ it.describe("comb.Promise", function (it) {
                     setTimeout(comb.hitch(promise3, "callback", res + " error"), 1000);
                     return promise3;
                 }).then(function (res) {
+                    console.log(res);
                     assert.equal(res, "error error error")
                     next();
                 }, next);


### PR DESCRIPTION
If no explicit errback is passed to chain() then the error is propagated to the next link. This allows for centralised error handling by using the following pattern:

```
this.task1()
    .chain(hitch(this, 'task2'))
    .chain(hitch(this, 'task3'))
    .chain(hitch(this, 'task4'))
    .then(
        function () {
            // Success
        },
        function (err) {
            // A task failed
        }
    );
```

This pattern is very handy for situations like updating numerous database tables.
