### PR TITLE
keeping a reference to error objects on log messages

### DIFF
--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -370,7 +370,7 @@ Logger = (logging.Logger = define.define(null, {
          * @param {String} message the message to be logged
          * @return {Object} the logging event
          */
-        getLogEvent: function getLogEvent(level, message) {
+        getLogEvent: function getLogEvent(level, message, rawMessage) {
             return {
                 hostname: os.hostname(),
                 pid: process.pid,
@@ -380,7 +380,8 @@ Logger = (logging.Logger = define.define(null, {
                 levelName: level.name,
                 message: message,
                 timeStamp: new Date(),
-                name: this.fullName
+                name: this.fullName,
+                rawMessage: rawMessage
             };
         },
 
@@ -393,7 +394,9 @@ Logger = (logging.Logger = define.define(null, {
          * @return {comb.logging.Logger} for chaining.
          */
         log: function log(level, message) {
+            var rawMessage = message;
             level = Level.toLevel(level);
+
             if (this.hasLevelGt(level)) {
                 var args = argsToArray(arguments, 1);
                 if (args.length > 1) {
@@ -409,7 +412,7 @@ Logger = (logging.Logger = define.define(null, {
                     message = message.stack;
                 }
                 var type = level.name.toLowerCase(), appenders = this.__appenders;
-                var event = this.getLogEvent(level, message);
+                var event = this.getLogEvent(level, message, rawMessage);
                 Object.keys(appenders).forEach(function (i) {
                     appenders[i].append(event);
                 });
@@ -736,5 +739,3 @@ rootTree = rootLogger._tree;
  * @type comb.logging.Logger
  */
 exports.logger.rootLogger = rootLogger;
-
-


### PR DESCRIPTION
This enables our logger to actually use the error object.

- [ ] @doug-martin 
- [x] @aheuermann 
