### PR TITLE
Altered underscore method to fix refresh_db

### DIFF
--- a/lib/base/inflections.js
+++ b/lib/base/inflections.js
@@ -11,8 +11,9 @@ var comb = exports;
 var CAMELIZE_CONVERT_REGEXP = /_(.)/g;
 var DASH = '-';
 var UNDERSCORE = '_';
-var UNDERSCORE_CONVERT_REGEXP1 = /([A-Z]+)(\d+|[A-Z][a-z])/g;
-var UNDERSCORE_CONVERT_REGEXP2 = /(\d+|[a-z])(\d+|[A-Z])/g;
+var UNDERSCORE_CONVERT_REGEXP1 = /([a-z]+)([A-Z])/g;
+var UNDERSCORE_CONVERT_REGEXP2 = /([a-z]|[A-Z])(\d+)/g;
+var UNDERSCORE_CONVERT_REGEXP3 = /(\d+)([a-z]|[A-Z])/g;
 var UNDERSCORE_CONVERT_REPLACE = '$1_$2';
 
 var PLURALS = [], SINGULARS = [], UNCOUNTABLES = [];
@@ -131,6 +132,7 @@ comb.underscore = function (str) {
     if (!misc.isUndefinedOrNull(str)) {
         ret = str.replace(UNDERSCORE_CONVERT_REGEXP1, UNDERSCORE_CONVERT_REPLACE)
             .replace(UNDERSCORE_CONVERT_REGEXP2, UNDERSCORE_CONVERT_REPLACE)
+            .replace(UNDERSCORE_CONVERT_REGEXP3, UNDERSCORE_CONVERT_REPLACE)
             .replace(DASH, UNDERSCORE).toLowerCase();
     }
     return ret;

--- a/test/base/inflections.test.js
+++ b/test/base/inflections.test.js
@@ -84,6 +84,10 @@ it.describe("comb/base/inflections.js", function (it) {
         assert.equal(comb("1HelloWorld").underscore(), "1_hello_world");
         assert.equal(comb("column_name").underscore(), "column_name");
         assert.equal(comb("columnName").underscore(), "column_name");
+        assert.equal(comb("hello1World").underscore(), "hello_1_world");
+        assert.equal(comb("helloWorld10").underscore(), "hello_world_10");
+        assert.equal(comb("10hello10World10").underscore(), "10_hello_10_world_10");
+        assert.equal(comb("10hello10world10").underscore(), "10_hello_10_world_10");
     });
 
     it.should("classify correctly", function () {


### PR DESCRIPTION
Previously the underscore method wasn't treating trailing/embedded digits as capital words. Eg:  

`comb.underscore("My100Things") = my_100things`

The presumed desired behavior would be:  

`comb.underscore("My100Things") = my_100_things`

or

`comb.underscore("ProductVersion100") = "product_version_100"
