### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/History.md
+++ b/History.md
@@ -78,7 +78,7 @@
 
 * Fixed memory leak in promise.
 
-#0.2.7
+# 0.2.7
 
 * Fixed object.deepEquals reference of isUndefinedNull.
 
@@ -102,10 +102,10 @@
 * Updated define to be more performant
 * Rewrote Promise#chain
 
-#0.2.1
+# 0.2.1
 * Added check for `getgid` when logging on non posix systems
 
-#0.2.0 / 2012-11-20
+# 0.2.0 / 2012-11-20
 * Added new features to comb.define
   * extend - supports direct extension `Mammal.extend({})`
   * define now accepts a hash directly istead of requiring null if there is not a super
@@ -118,7 +118,7 @@
 
 
 
-#0.1.10 / 2012-11-14
+# 0.1.10 / 2012-11-14
 * Added new properites to logger events
   * gid
   * pid
@@ -126,21 +126,21 @@
   * hostname
 
 
-#0.1.91 / 2012-10-01
+# 0.1.91 / 2012-10-01
 * Added `_getSuper` to classes declared with comb.define
 
-#0.1.9 / 2012-09-22
+# 0.1.9 / 2012-09-22
 * Change comb.array.intersection to not use recursion
 * added `comb.wait`
 
-#0.1.8/2012-09-10
+# 0.1.8/2012-09-10
 * Added travis CI build
 * Updated comb.date to use maps where possible and removed switch statements to use else if
 * Updated tests to run as expected each time
 * Updated tests to be timezone agnostic
 * Fixed console appender test
 
-#0.1.7/2012-09-05
+# 0.1.7/2012-09-05
 * comb.async
  * forEach
  * map
@@ -177,16 +177,16 @@
 * Updated docs
 
 
-#0.1.6/2012-08-29
+# 0.1.6/2012-08-29
 * Changed comb.when to accept an array of promises as well as multi args
 * Added comb.chain to pipe results from one item to another
 * Updated docs and tests
 
 
-#0.1.5/2012-08-26
+# 0.1.5/2012-08-26
 * Changed middleware plugin to error properly
 
-#0.1.4/2012-08-20
+# 0.1.4/2012-08-20
 * added new short cut for configuring loggers
 * Added changed logger.addAppender to accept a string and options to use Appender.createAppender method.
 * comb.argsToArray now takes a slice argument to remove arguments.
@@ -194,7 +194,7 @@
 * Added a "promise" method to comb.Promise to allow for the return of an object that will not allow calling function to resolve the promise.
 * Cleaned up promise using code to return the "promise" wrapper.
 
-#0.1.3/2012-08-16
+# 0.1.3/2012-08-16
 * new array methods
   * sort
   * min
@@ -206,25 +206,25 @@
   * Changed appenders to register themselves for dynamic appender creation
 * Updated docs
 
-#0.1.2/2012-07-17
+# 0.1.2/2012-07-17
 * Bug fixes
   * Changed comb.logging.PropertyConfigurator to deep merge porperties (Clone to config object)
 * Added comb.array.multiply
 * Updated docs to use [coddoc](https://github.comb/doug-martin/coddoc)
 
-#0.1.1/2012-04-20
+# 0.1.1/2012-04-20
 
   * Migrated all tests to use [it](http://github.com/doug-martin/it)
   * More Tests
   * Added functionality to comb.Promise/PromiseList (allowing promises as callbacks and node style callbacks for)
 
-#0.1.0/2012-03-02
+# 0.1.0/2012-03-02
 
   * comb.define performance increase
   * Changed HashTable to use strict equal
   * Doc fixes
 
-#0.0.9 /2012-02-16
+# 0.0.9 /2012-02-16
 
   * Complete redesign of comb.define to be more flexible and efficient
      * this._super does not require and Arguments object any more to call super
@@ -253,13 +253,13 @@
 
 
 
-#0.0.8 / 2012-02-9
+# 0.0.8 / 2012-02-9
 
   * Added new MethodMissing plugin
   * Bug fixes
     * Changed inflections to underscore between word boundaries and numbers and vice versa with camelize.
 
-#0.0.7 / 2012-02-04
+# 0.0.7 / 2012-02-04
 
   * Bug Fixes
   * Fixed issue with array.zip
@@ -273,7 +273,7 @@
   * Updated docs.
 
 
-#0.0.6 / 2011-12-29
+# 0.0.6 / 2011-12-29
 
   * Bug Fixes
   * Added new Proxy methods
@@ -286,7 +286,7 @@
   * static initialization block on objects using comb.define
   * more tests
 
-#0.0.3 / 2011-06-23
+# 0.0.3 / 2011-06-23
 
   * 100% test coverage
   * Bug fixes
@@ -300,7 +300,7 @@
     * make uninstall
   * Added jscoverage sub module
 
-#0.0.2 / 2011-06-11
+# 0.0.2 / 2011-06-11
 
 
   * Added Logging
@@ -308,7 +308,7 @@
   * String styling
   * Updated Docs.
 
-#0.0.1 / 2011-05-19
+# 0.0.1 / 2011-05-19
 
 
   * Initial release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![build status](https://travis-ci.org/C2FO/comb.svg?branch=master)](http://travis-ci.org/C2FO/comb)
 [![Coverage Status](https://coveralls.io/repos/C2FO/comb/badge.svg?branch=master&service=github)](https://coveralls.io/github/C2FO/comb?branch=master)
 
-#Comb
+# Comb
 
 
-##Overview                                                                                                                                         
+## Overview                                                                                                                                         
 
 Framework for node that provides a one stop shop for frequently needed utilities, including:                                                       
 
@@ -15,13 +15,13 @@ Framework for node that provides a one stop shop for frequently needed utilities
 * [Flow control](http://c2fo.github.com/comb/promise.html)                                                                                                                   
 
 
-##Installation                                                                                                                                     
+## Installation                                                                                                                                     
 
 `npm install comb`
 
-###[Getting Started](http://c2fo.github.com/comb/introduction.html)
+### [Getting Started](http://c2fo.github.com/comb/introduction.html)
 
-##Highlights                                                                                                                                       
+## Highlights                                                                                                                                       
 
 * 100% test coverage!                                                                                                                              
 * comb([define](http://c2fo.github.com/comb/comb.html#.define)|[singleton](http://c2fo.github.com/comb/comb.html#.singleton))                                                                          
@@ -57,12 +57,12 @@ Framework for node that provides a one stop shop for frequently needed utilities
   * [comb.when](http://c2fo.github.com/comb/comb.html#.when)                                                                                                                 
   * [comb.serial](http://c2fo.github.com/comb/comb.html#.serial)                                                                                                             
 
-##License
+## License
 
 
 MIT <https://github.com/c2fo/comb/raw/master/LICENSE>
 
-##Meta
+## Meta
 
 * Code: `git clone git://github.com/c2fo/comb.git`
 * JsDoc: <http://c2fo.github.com/comb>

--- a/docs-md/define.md
+++ b/docs-md/define.md
@@ -1,8 +1,8 @@
 
-#[define](./comb.html#.define)
+# [define](./comb.html#.define)
 
 
-##Instance Methods 
+## Instance Methods 
 
 
 When defining classes in `comb` there are two root level properties you can define,  `instance` and  `static`. 
@@ -260,7 +260,7 @@ try {
 }
 ```
 
-##Static Methods
+## Static Methods
 
 
 As stated above  `comb.define` looks for an optional static  property on the `prototype` declaration  of a class. 
@@ -330,7 +330,7 @@ myMammal = new Mammal();
 console.log(myMammal.type); //prints whale
 ```
 
-###Inheritance In Static Functions.
+### Inheritance In Static Functions.
 
 
 One neat thing about defining classes in `comb` is that you not only get the advantages of inheritance in instance methods but static methods as well. So lets modify `Dog` and `Wolf` to take advantage of that.
@@ -448,13 +448,13 @@ console.log(WolfDog.soundOff());
 As you can see inheritance within the static methods follows the same order as it does within  the instance methods.
 
 
-###Static Getters and Setters
+### Static Getters and Setters
 
 
 Getters and setters are declared the same way in a static declaration as they are in an instance declaration.
 
 
-###Getting an Instance of my self.
+### Getting an Instance of my self.
 
 
 One nuance about prototypal inheritance is that the scope in which a function is called is not consistent. For example, lets add a reproduce method to `Mammal`.
@@ -520,7 +520,7 @@ sameSpecies : function(obj){
 
 This comes in handy when dealing with multiple inheritance, and wanting to check if an object is of the same concrete class.
 
-###Static initialization
+### Static initialization
 
 `comb.define` also provides a mechanism for initializing when creating a class. `init` will be called on creation of any class.
 

--- a/docs-md/introduction.md
+++ b/docs-md/introduction.md
@@ -1,4 +1,4 @@
-#Comb
+# Comb
 
 `comb` can be used as a namespace or a `function` when using comb as a `function` it decorates the passed in value with methods that can be chained togther or used stand alone. The following types are supported.
 
@@ -12,9 +12,9 @@
 * [Argument](#arguments)
 * `RegExp`
 
-##Notes
+## Notes
 
-###Strict Equalities
+### Strict Equalities
 
 When comparing primitives you should use the `eq` and `neq` methods as primitives are coverted to their Object counter parts.
 
@@ -31,7 +31,7 @@ console.log(combOne.neq(one)); //false
 ```
 
 
-###Printing values.
+### Printing values.
 
 When using `console.log` you should convert primitive values to strings either trough the toString method or `"" + value' otherwise you will end up with the object printed instead of the expected value.
 
@@ -42,7 +42,7 @@ comb("hello").print(); //"hello"
 ```
 
 
-##Common Methods
+## Common Methods
 
 Comb will be default decorate any value passed in with the following methods.
 
@@ -88,11 +88,11 @@ value.deepEqual({a : "b", c : "b"})); //false
 ```
 
 <a name="arrays"></a>
-##Arrays
+## Arrays
 
 `Array`s will be decorated with the following functions.
 
-###`style`
+### `style`
 Styles each string in the array.
 
 ```
@@ -100,7 +100,7 @@ Styles each string in the array.
 comb(["red", "green","blue"]).style("red").join("\n")); 
 ```
 
-###`forEach`
+### `forEach`
 
 Chainable version of `Array.prototype.forEach` returning the original array
 
@@ -117,31 +117,31 @@ comb([1,2,3])
 	});
 ```
 
-###`map`
+### `map`
 
 Same as `Array.prototype.map` but the return value is decorated with all the array methods.
 
-###`filter`
+### `filter`
 
 Same as `Array.prototype.filter` but the return value is decorated with all the array methods.
 
-###`reduce`
+### `reduce`
 
 Same as `Array.prototype.filter` but the return value is decorated by `comb`.
 
-###`reduceRight`
+### `reduceRight`
 
 Same as `Array.prototype.reduceRight` but the return value is decorated by `comb`.
 
-###`indexOf`
+### `indexOf`
 
 Same as `Array.prototype.indexOf` but with a decorated number.
 
-###`lastIndexOf`
+### `lastIndexOf`
 
 Same as `Array.prototype.lastIndexOf` but with a decorated number.
 
-###`zip`
+### `zip`
 
 Zips array together.
 
@@ -151,7 +151,7 @@ comb([1, 2]).zip([2], [3]); // [[ 1, 2, 3 ], [2, null, null]]
 comb([1, 2, 3]).zip(a, b);  //[[1, 4, 7],[2, 5, 8],[3, 6, 9]]
 ```
 
-###`sum`
+### `sum`
 
 Sums an array
 
@@ -160,7 +160,7 @@ comb([1,2,3]).sum(); //6
 comb([1,2,3]).sum().isNumber(); //true
 ```
 
-###`avg`
+### `avg`
 
 Finds the average of an array of numbers.
 
@@ -169,7 +169,7 @@ comb([1,2,3]).avg(); //2
 comb([1,2,3]).avg().isNumber(); //true
 ```
 
-###`sort`
+### `sort`
 
 Sorts an array. **NOTE** This does not change the original array.
 
@@ -184,7 +184,7 @@ comb(arr).pluck("a");           //[3,2,1]
 
 ```
 
-###`min`
+### `min`
 
 Finds the minimum value in an array.
 
@@ -196,7 +196,7 @@ var arr2 = [{a : 3}, {a : 2}, {a : 1}];
 comb(arr).min("a"); //{a : 1}
 ```
 
-###`max`
+### `max`
 
 Finds the maximum value in an array.
 
@@ -208,7 +208,7 @@ var arr2 = [{a : 3}, {a : 2}, {a : 1}];
 comb(arr).max("a"); //{a : 3}
 ```
 
-###`difference`
+### `difference`
 
 Finds the difference between two arrays.
 
@@ -220,7 +220,7 @@ comb(["a", "b", 3]).difference([3]);    //["a", "b"]
 comb([a, b, c]).difference([b, c]);     //[a]
 ```
 
-###`removeDuplicates`
+### `removeDuplicates`
 
 Removes duplicates from an array.
 
@@ -229,7 +229,7 @@ comb([1, 2, 2, 3, 3, 3, 4, 4, 4]).removeDuplicates(); //[1, 2, 3, 4]
 comb(["a", "b", "b"]).removeDuplicates();             // ["a", "b"]
 ```
 
-###`unique`
+### `unique`
 
 Alias to `removeDuplicates`
 
@@ -238,7 +238,7 @@ comb([1, 2, 2, 3, 3, 3, 4, 4, 4]).unique(); // [1, 2, 3, 4]);
 comb(["a", "b", "b"]).unique();            // ["a", "b"]);
 ```
 
-###`rotate`
+### `rotate`
 
 Rotates an array by `1` or the specified number of places.
 
@@ -255,7 +255,7 @@ arr.rotate(-4); // ["a", "b", "c", "d"]);
 
 ```
 
-###`permutations`
+### `permutations`
 
 Finds all permutaions of the array.
 
@@ -286,7 +286,7 @@ arr.permutations(1); //[
 					  //]
 ```
 
-###`transpose`
+### `transpose`
 
 Transposes a multidimensional array.
 
@@ -298,7 +298,7 @@ comb([[1, 2, 3],[4, 5, 6]]).transpose(); //[
 										  //]
 ```
 
-###`valuesAt`
+### `valuesAt`
 
 Retrieves the values at the specified locations.
 
@@ -309,7 +309,7 @@ arr.valuesAt(1, 2, 3, 4); //["b", "c", "d", null]);
 arr.valuesAt(0, 3);       //["a", "d"]);
 ```
 
-###`union`
+### `union`
 
 Returns the union of the value with the passed in arrays.
 
@@ -318,7 +318,7 @@ comb(["a", "b", "c"]).union(["b", "c", "d"]);  //["a", "b", "c", "d"]);
 comb(["a"]).union(["b"], ["c"], ["d"], ["c"]); //["a", "b", "c", "d"]);
 ```
 
-###`intersect`
+### `intersect`
 
 Finds the intersection of arrays.
 
@@ -330,7 +330,7 @@ comb([1, 2, 3, 4, 5]).intersect([1, 2, 3, 4, 5], [1, 2, 3]); //[1, 2, 3]
         
 ```
 
-###`powerSet`
+### `powerSet`
 
 Finds the powerset of an array.
 
@@ -343,7 +343,7 @@ comb([1, 2]).powerSet()); //[
 						   //]
 ```								       
 
-###`cartesian`
+### `cartesian`
 
 Finds the cartesian product of arrays.
 
@@ -356,7 +356,7 @@ comb([1, 2]).cartesian([2, 3]); //[
 						         //]
 ```
 
-###`compact`
+### `compact`
 
 Compacts an array removing `undefined` or `null`.
 
@@ -364,7 +364,7 @@ Compacts an array removing `undefined` or `null`.
 comb([1, null, undefined, x, 2]).compact(); //[1, 2]
 ```
 
-###`multiply`
+### `multiply`
 
 Duplicates the elements in an array the specified number of times.
 
@@ -372,7 +372,7 @@ Duplicates the elements in an array the specified number of times.
 comb([1, 2, 3]).multiply(2); //[1, 2, 3, 1, 2, 3]
 ```
 
-###`flatten`
+### `flatten`
 
 Flattens arrays.
 
@@ -383,7 +383,7 @@ comb([[1, 2],2]).flatten([2, 3], [3, 4]); //[[1, 2],2,2,3,3,4]
 
 ```
 
-###`pluck`
+### `pluck`
 
 Plucks values from each item in the array.
 
@@ -401,7 +401,7 @@ arr.pluck("roles.length"); //[3, 2, 1, 0]
 arr.pluck("roles.0"); //["a", "b", "c", undefined]            
 ```
 
-###`invoke`
+### `invoke`
 
 Invokes the specified method on each item in the array.
 
@@ -432,9 +432,9 @@ arr.invoke("getName"); //["Bob", "Alice", "Fred", "Johnny"]
 arr.invoke("getOlder").invoke("getAge"); //[41, 36, 51, 57];                                                                                                     
 ```
 <a name="strings"></a>
-##Strings
+## Strings
 
-###`style`
+### `style`
 
 Styles a string. See [comb.string.style](./comb_string.html#.style) for style types. 
 ```
@@ -445,7 +445,7 @@ comb("string").style(["green", "bold"])
 
 ```
 
-###`multiply`
+### `multiply`
 
 Repeats the string the specified number of times.
 
@@ -453,7 +453,7 @@ Repeats the string the specified number of times.
 comb("HELLO ").multitply(5)); ///"HELLO HELLO HELLO HELLO HELLO"
 ```
 
-###`toArray`
+### `toArray`
 
 ```
 comb("a|b|c|d").toArray("|"); //["a","b","c","d"]
@@ -461,7 +461,7 @@ comb("a").toArray("|");       //["a"]
 comb("").toArray("|");        //[]
 ```
 
-###`format`
+### `format`
 
 Formats a string. See [comb.string.format](./comb_string.html#.format) for formatting flags.
 
@@ -497,7 +497,7 @@ comb("{[-s10]apple}, {[%#10]orange}, {[10]banana} and {[-10]watermelons}").forma
 }); //applesssss, ####orange,    bananas and watermelon
 ```
 
-###`truncate`
+### `truncate`
 
 Truncates a string.
 
@@ -510,7 +510,7 @@ comb("abcdefg").truncate(3,true); // "efg"
 comb("abcdefg").truncate();       //"abcdefg"
 ```
 
-###`pad`
+### `pad`
 
 Pads a string with.
 
@@ -521,7 +521,7 @@ str.pad(5, " ", true); //"STR  "
 str.pad(5, "$", true); //"$$STR"
 ```
 
-###`camelize`
+### `camelize`
 
 Camelize an underscored string.
 
@@ -531,7 +531,7 @@ comb('column_name').camelize(); // "columnName"
 comb('columnName').camelize();  // "columnName"
 ``` 
 
-###`underscore`
+### `underscore`
 
 Underscore a camelcased string.
 
@@ -541,7 +541,7 @@ comb('column_name').underscore(); // "column_name"
 comb('columnName').underscore();  // "column_name"
 ``` 
 
-###`classify`
+### `classify`
 
 Singularizes and camelizes the string. Also strips out all characters preceding and including a period (".").
 
@@ -551,7 +551,7 @@ comb('post').classify();         //"post"
 comb('schema.post').classify();  //"post"
 ```
 
-###`pluralize`
+### `pluralize`
 
 Returns the plural form of the string.
 
@@ -564,7 +564,7 @@ comb("the blue mailman").pluralize(); //"the blue mailmen"
 comb("CamelOctopus").pluralize();     //"CamelOctopi"
 ```
 
-###`singularize`
+### `singularize`
 
 The reverse of `pluralize` returns the singluar version of a string.
 
@@ -577,7 +577,7 @@ comb("the blue mailmen").singularize()); //"the blue mailman"
 comb("CamelOctopi").singularize());      //"CamelOctopus"
 ```
 
-###`applyFirst`
+### `applyFirst`
 
 Creates a function that will invoke the method with the strings name on the first argument passed in.
 
@@ -588,7 +588,7 @@ length(arr); //4
 console.log(arr); //1,2,3,4                                                                                                                                          
 ```
                                                                                 
-###`bindFirst`
+### `bindFirst`
 Alias to apply first.
 
 ```                                                                                
@@ -599,7 +599,7 @@ console.log(arr); //1,2,3,4
                                                                                    
 ```
 
-###`partial`
+### `partial`
 
 Creates a function that curries arguments but does not change the scope.
 
@@ -614,7 +614,7 @@ var scope = {
 func.call(scope); //true
 ```
 
-###`parseDate`
+### `parseDate`
 
 Parses a date string. See [comb.date.parse](./comb_date.html#.parse) for formatting options.
 
@@ -628,7 +628,7 @@ comb("August 11, 2006").date.parse("MMMM dd, yyyy");          //aug_11_2006
 comb("Friday, August 11, 2006").parse("EEEE, MMMM dd, yyyy"); //aug_11_2006
 ```
 
-###`escape`
+### `escape`
 
 Escapes a string.
 
@@ -636,7 +636,7 @@ Escapes a string.
 comb(".$?*|{}()[]\/+^").escape() + ""); //^"
 ```
 
-###`pluck`
+### `pluck`
 
 Inverted form of `comb.array.pluck`. 
 
@@ -654,7 +654,7 @@ comb("roles.length").pluck(arr); //[3, 2, 1, 0]
 comb("roles.0").pluck(arr); //["a", "b", "c", undefined] 
 ```
 
-###`invoke`
+### `invoke`
 
 Inverted of `comb.array.invoke`.
 
@@ -685,7 +685,7 @@ comb("getName").invoke(arr); //["Bob", "Alice", "Fred", "Johnny"]
 comb("getOlder").invoke(arr).invoke("getAge"); //[41, 36, 51, 57];
 ```
 
-###`hitch`
+### `hitch`
 
 Hitches a named method on an object.
 
@@ -706,7 +706,7 @@ test(); // "hello"
 curried("!"); //["hello", "world", "!"]
 ```
 
-###`bind`
+### `bind`
 
 Binds a named method on an object.
 
@@ -728,7 +728,7 @@ curried("!"); //["hello", "world", "!"]
 
 ```
 
-###`hitchIgnore`
+### `hitchIgnore`
 
 Hitches a named method on an object ignoring passed in arguments.
 
@@ -744,7 +744,7 @@ var curried = comb("curried").hitchIgnore(obj, "world");
 curried("!"); //["hello", "world"]
 ```
 
-###`bindIgnore`
+### `bindIgnore`
 
 Binds a named method on an object ignoring passed in arguments.
 
@@ -760,7 +760,7 @@ var curried = comb("curried").bindIgnore(obj, "world");
 curried("!"); //["hello", "world"]
 ```
 
-###`curry`
+### `curry`
 
 Curries arguments the specified number of times in the specified scope.
 
@@ -778,9 +778,9 @@ curriedFunc("a")("b")("c")("d"); //[true, "a", "b", "c", "d"]
 ```
 
 <a name="dates"></a>
-##Dates
+## Dates
 
-###`add`
+### `add`
 
 Add the specified interval the specified number of times. See [comb.date.add](./comb_date.html#.add) for more arugment types.
 
@@ -798,7 +798,7 @@ dateFormat(dt.add("milliseconds", 2)); //2009-02-01 01:01:01.113
 
 ```
 
-###`compare`
+### `compare`
 
 compares this date to another.
 
@@ -819,7 +819,7 @@ comb(d2).compare(d1, "datetime") //-1
 
 ```
 
-###`difference`
+### `difference`
 
 Finds the difference between two dates. See [comb.date.difference](./comb_date.html#.difference).
 
@@ -829,7 +829,7 @@ comb(new Date(2005, 11, 27)).difference(new Date(2006, 11, 27), "year"); //1
 
 ```
 
-###`format`
+### `format`
 
 Formats a date with the specified formatting flags. See [comb.date.format](./comb_date.html#.format). 
 
@@ -840,7 +840,7 @@ date.format("yyyy-MM-dd"); //2011-02-01
 date.format("HH:mm:ss.SSS"); //01:01:01.111
 ```
 
-###`getDaysInMonth`
+### `getDaysInMonth`
 
 Returns the days in the dates month.
 
@@ -854,10 +854,10 @@ comb(new Date(1700, 1, 1)).getDaysInMonth() //28
 comb(new Date(1600, 1, 1)).getDaysInMonth() //29
 ```
 
-###`getTimezoneName`
+### `getTimezoneName`
 Returns the name of the timezone for the date.
 
-###`isLeapYear`
+### `isLeapYear`
 
 Returns a boolean indicating if the year is leap year.
 
@@ -871,7 +871,7 @@ comb(new Date(1800, 0, 1)).isLeapYear(); //false
 comb(new Date(1700, 0, 1)).isLeapYear(); //false
 ```
 
-###`isWeekend`
+### `isWeekend`
 
 Returns if the date falls on a weekend.
 
@@ -887,9 +887,9 @@ monday.isWeekend(); //false
 ```
 
 <a name="functions"></a>
-##Functions
+## Functions
 
-###`hitch`
+### `hitch`
 
 Hitches a function to the specified scope, currying any extra arguments.
 
@@ -903,7 +903,7 @@ add(11); //26
 add(12); //28
 ```
 
-###`bind`
+### `bind`
 
 Hitches a function to the specified scope, currying any extra arguments.
 
@@ -917,7 +917,7 @@ add(11); //26
 add(12); //28
 ```
 
-###`hitchIgnore`
+### `hitchIgnore`
 
 Hitches a function to the specified scope, ignoring any extra arguments.
 
@@ -932,7 +932,7 @@ add(11); //4
 add(12); //4
 ```
 
-###`bindIgnore`
+### `bindIgnore`
 
 Hitches a function to the specified scope, ignoring any extra arguments.
 
@@ -947,7 +947,7 @@ add(11); //4
 add(12); //4
 ```
 
-###`partial`
+### `partial`
 
 Returns a function that does not change execution scope but curries arguments.
 
@@ -965,7 +965,7 @@ arr.pushTwo(3);
 console.log(arr); //[[2,1], [2,3]]
 ```
 
-###`applyFirst`
+### `applyFirst`
 
 Creates a function that runs in the scope of the first arugment, and applies the rest.
 
@@ -983,7 +983,7 @@ console.log(arr); //[ [ 2, 1 ], [ 2, 2 ], [ 2, 3 ] ]
 
 ```
 
-###`bindFirst`
+### `bindFirst`
 
 Same as apply first.
 
@@ -1000,7 +1000,7 @@ pushTwo(arr, 3);
 console.log(arr); //[ [ 2, 1 ], [ 2, 2 ], [ 2, 3 ] ]
 ```
 
-###`curry`
+### `curry`
 
 Curries a function the specified number of times.
 
@@ -1012,7 +1012,7 @@ var curried = func.curry(4, {test:true});
 console.log(curried("a")("b")("c")("d"));
 ```
 
-###`extend`
+### `extend`
 
 Extends the prototype of a function.
 
@@ -1034,9 +1034,9 @@ console.log(m2.getStr()); //"world"
 ```
 <a name="numbers"></a>
 
-##Number
+## Number
 
-###`round`
+### `round`
 Rounds a number. See [comb.number.round](./comb_number.html#.round)
 
 ```
@@ -1048,7 +1048,7 @@ comb(10.0009).round(3).print();    //10.001
 comb(10.0009).round(2, 1).print(); //11
 ```
 
-###`roundCeil`
+### `roundCeil`
 
 Rounds a number up. See [comb.number.roundCeil](./comb_number.html#.roundCeil)
 
@@ -1063,9 +1063,9 @@ comb(10.0004).roundCeil(2).print();    //10.01
 ```
 
 <a name="objects"></a>
-##Objects
+## Objects
 
-###`hitch`
+### `hitch`
 
 Hitches a function to run in the scope of this object.
 
@@ -1080,7 +1080,7 @@ func(); //"test";
 
 ```
 
-###`hitchIgnore`
+### `hitchIgnore`
 
 Hitches a function to run in the scope of this object, ignoring extra arguments.
 
@@ -1095,7 +1095,7 @@ func("hello"); //["test"];
 
 ```
 
-###`bind`
+### `bind`
 
 Binds a function to run in the scope of this object.
 
@@ -1110,7 +1110,7 @@ func(); //"test";
 
 ```
 
-###`bindIgnore`
+### `bindIgnore`
 
 Binds a function to run in the scope of this object, ignoring extra arguments.
 
@@ -1125,7 +1125,7 @@ func("hello"); //["test"];
 
 ```
 
-###`merge`
+### `merge`
 
 Merges another object into this object.
 
@@ -1135,7 +1135,7 @@ console.log(obj.merge({b : "c"})); //{a : "b", b : "c"}
 console.log(obj.merge({a : "d"})); //{a : "d", b : "c"}
 ```
 
-###`extend`
+### `extend`
 
 Merges another object into this object.
 
@@ -1145,7 +1145,7 @@ console.log(obj.extend({b : "c"})); //{a : "b", b : "c"}
 console.log(obj.extend({a : "d"})); //{a : "d", b : "c"}
 ```
 
-###`deepMerge`
+### `deepMerge`
 
 Deeply merges another object into this object, meaning that merges in nested objects.
 
@@ -1201,7 +1201,7 @@ format.format([obj.merge({a:{d:{f:{g:1}}}})]).print();
  */
 ```
 
-###`forEach`
+### `forEach`
 
 Iterate through each key/value pair in an object.
 
@@ -1213,7 +1213,7 @@ comb(obj).forEach(function(value, key){
                            
 ```
 
-###`filter`
+### `filter`
 
 Filters out key/value pairs in an object. Filters out key/value pairs that return a falsey value from the iterator.
                                                                                                                    
@@ -1225,7 +1225,7 @@ comb(obj).filter(function(value, key){
                                                                                                                    
 ```                                                                                                                
 
-###`invert`
+### `invert`
 
  Returns a new hash that is the invert of the hash.   
                                                       
@@ -1234,7 +1234,7 @@ comb(obj).filter(function(value, key){
  comb(obj).invert(); //{b : "a", d : "c", f : "e"}                                                         
  ```                                                  
 
-###`values`
+### `values`
 
 Returns the values of a hash.             
                                           
@@ -1243,7 +1243,7 @@ var obj = {a : "b", c : "d", e : "f"};
 comb(obj).values(); //["b", "d", "f"]                                                                                          
 ```
 
-###`pick`
+### `pick`
 
 Pick certain key/value pairs from a hash
 
@@ -1253,7 +1253,7 @@ comb(obj).pick(["a", "b"]); //{a: "a", b:'b'}
 comb(obj).pick("c"); //{c: "c"};
 ```
 
-###`omit`
+### `omit`
 
 Omit certain key/value pairs from a hash
 
@@ -1263,7 +1263,7 @@ comb(obj).omit(["a", "b"]); //{c: "c"}
 comb(obj).omit("c"); //{a: "a", b: "b"};
 ```
 
-###`toArray`
+### `toArray`
 
 Converts a hash to an array.                                    
                                                                 
@@ -1273,9 +1273,9 @@ comb(obj).toArray(); //[["a", "b"], ["c", "d"], ["e", "f"]]
 ```
 
 <a name="arguments"></a>
-##Arguments
+## Arguments
 
-###`toArray`
+### `toArray`
  
 Converts an arugments object to an array.
 

--- a/docs-md/logging.md
+++ b/docs-md/logging.md
@@ -1,4 +1,4 @@
-##Logging.
+## Logging.
 
 `comb`'s logging api is fairly straight forward.
 
@@ -26,7 +26,7 @@ var logger = comb.logger("logger");
 
 Both of the previous loggers are one and the same.
 
-###Logger inheritance
+### Logger inheritance
 
 As with other logging APIs loggers can inherit from eachother, through a **dot** notation.
 
@@ -47,7 +47,7 @@ So what does this inheritance mean?
 
 Well it has to do with logging `levels` and `appenders`.
 
-####Levels
+#### Levels
 In the above examples we could define a level of `INFO` to the logger `my` and a level of `ERROR` to `myOther` and all sub loggers would inherit the respective `level`. The same applies for `appender`s  any appenders added to a logger will be propogated down. So lets look at an example.
 
 ```
@@ -94,7 +94,7 @@ setTimeout(function(){
 }, 5000);
 ```
 
-####Appenders
+#### Appenders
 
 Appenders are the objects that handle events and deliver them to where they need to go. `comb` supports a few types of appenders out of the box.
 
@@ -112,13 +112,13 @@ var myLogger = comb.logger("my.logger")
     .addAppender("JSONAppender", {file:'/var/log/myJson.log'});        
 ```
 
-##Configuring your loggers
+## Configuring your loggers
 
 Ok so now that we have an idea of the different aspects of a logger, lets look at configuring your loggers.
 
 To configure your loggers just call `comb.logger.configure`
 
-###Default configuration
+### Default configuration
 
 If you call `comb.logger.configure` without any arguments then a [ConsoleAppender](./comb_logging_appenders_ConsoleAppender.html) will be added to all loggers.
 
@@ -139,7 +139,7 @@ var myLogger = comb.logger("my.logger");
 
 ```
 
-###Configuring with JSON or a File
+### Configuring with JSON or a File
 
 You can also pass in either the location of a log configuration or an object with your configuration.
 
@@ -185,7 +185,7 @@ comb.logger.configure({
 })                                                                                               
 ```
 
-##Log Line Format
+## Log Line Format
 
 [ConsoleAppender](./comb_logging_appenders_ConsoleAppender.html), [FileAppender](./comb_logging_appenders_FileAppender.html), and [RollingFileAppender](./comb_logging_appenders_RollingFileAppender.html) all support custom formatting for writing out log lines. 
 
@@ -216,7 +216,7 @@ var myLogger = comb.logger("my.logger")
 
 For more information on formatting syntax see [comb.string.format](./comb_string.html#.format).
 
-##Logging Messages
+## Logging Messages
 
 To log messages you can use [log](./comb_logging_Logger.html#log).
 

--- a/docs-md/promise.md
+++ b/docs-md/promise.md
@@ -1,8 +1,8 @@
-#[Promises](./comb_Promise.html)
+# [Promises](./comb_Promise.html)
 
 `comb` provides an async wrapper called a [promise](http://en.wikipedia.org/wiki/Futures_and_promises). Promises are a way of handling async and sync behavior by encapsulating it in a wrapper. One of the benefits of promises is that they encourage the separation of success and failure logic. Promises provide a value that can be passed around rather than providing callbacks for every async action. 
 
-##[comb.Promise](./comb_Promise.html)
+## [comb.Promise](./comb_Promise.html)
 
 The [comb.Promise](./comb_Promise.html) is the backbone for `comb`s async utilities. 
 
@@ -12,11 +12,11 @@ To create a promise
 var promise = new comb.Promise();
 ```
 
-###Resolving Promises
+### Resolving Promises
 
 When working with a promise you must resolve the promise in order for callbacks/errbacks to be invoked. Resolution can happen before for after callbacks/errbacks have been registered. The methods to resolve a promise are `callback`, `errback`, and `resolve`.
 
-###callback  and errback
+### callback  and errback
 
 The callback method is used to resolve a promise as a success.
 
@@ -45,7 +45,7 @@ readFile("myFile.txt").then(function(text){
 
 As you can see from above we can easily wrap the `fs.readFile` function with a promise. The advantage of this is that you can now seperate the success and error resolution paths with the `then` function. The above example just passes the error to a global error handler and your success callback does not have to worry about the error condition.
 
-###resolve
+### resolve
 
 `callback` and `errback` are great if you are working with other promise methods but as you can see from above you still have to handle the error and success path when working with node style callback. This is where the `resolve` method comes in handy.
 
@@ -71,11 +71,11 @@ readFile("myFile.txt").then(function(text){
 After rewriting the `readFile()` method with resolve the code is a lot cleaner with only three lines and you still get the same promise API.
 
 
-###Listening for Promise Resolutions
+### Listening for Promise Resolutions
 
 To listen for the resolution of promises there are the following methods. For the following examples we will use the `readFile` method defined above.
 
-###then
+### then
 The `then` methods accepts two arugments a `callback` and an optional `errback`.
 
 ```
@@ -126,7 +126,7 @@ readAndConvertToUppercase("myFile.txt").then(
 );
 ```
 
-###classic
+### classic
 
 The `classic` method can be used to register a callback with a node style callback
 
@@ -142,7 +142,7 @@ readFile("myFile.txt").classic(function(err, file){
 
 ```
 
-###chain
+### chain
 
 The chain method is used to chain promises together so they execute in order. The chain method is different from the [comb.serial](./comb.html#.serial) method in that it pipes the results from one promise into the next.
 
@@ -194,7 +194,7 @@ new Promise().callback()
     });
 ```
 
-###Catching Errors
+### Catching Errors
 
 Chain also allows you to catch errors so you can handle them successfully.
 
@@ -249,7 +249,7 @@ new Promise()
     });
 ```
 
-##[comb.PromiseList](./comb_PromiseList.html)
+## [comb.PromiseList](./comb_PromiseList.html)
 
 A promise list is used to listen for the completion of an array of promises. You may also use [comb.when](./comb.html#.when)
 with an array of promises.
@@ -271,7 +271,7 @@ readFiles("myFile.txt", "myFile2.txt", "myFile3.txt").then(function(files){
 ```
 
 
-##[comb.when](./comb.html#.when)
+## [comb.when](./comb.html#.when)
 
 The `comb.when` function allows one to wrap a sync or async call or calls with the same API.
 
@@ -314,7 +314,7 @@ readFiles("myFile.txt", "myFile2.txt", "myFile3.txt").then(function(files){
 }, errorHandler);
 ```
 
-##[comb.serial](./comb.html#.serial)
+## [comb.serial](./comb.html#.serial)
 
 The `comb.serial` function is useful if you need to perform a set of actions in order. The serial method takes a list of function that need to be executed in order. The return value of the functions can be anything if they are promises then the next function will not execute until the promise has resolved. The results from each function are will be the result of the returned promise. **NOTE** the results from each function are not propogated to the next.
 
@@ -340,7 +340,7 @@ comb.serial([
 });                                                                       
 ```
 
-##[comb.chain](./comb.html#.chain)
+## [comb.chain](./comb.html#.chain)
 
 The `comb.chain` method is similar to the `comb.serial` method except that it **does** propogate results from one function to the next. The promise returned from `comb.chain` will resolve with the result of the last action in the list.
 
@@ -369,7 +369,7 @@ comb.chain([
 });                                    
 ```
 
-##[comb.wrap](./comb.html#.wrap)
+## [comb.wrap](./comb.html#.wrap)
 
 The `comb.wrap` method is used to wrap a function that is defined with a node style callback in a promise.
 
@@ -396,7 +396,7 @@ fsp.rename("myFile.txt", "myFile.txt.bak").then(function(){
 });
 ```
 
-##[comb.async.forEach](./comb_async.html#.forEach)
+## [comb.async.forEach](./comb_async.html#.forEach)
 
 Loops through the results of an promise. The promise can return an array or just a single item.   
                                                                                                   
@@ -432,7 +432,7 @@ comb.async.forEach(asyncArr(), function(item, index){
 });                                                                                               
 ```                                                                                                                                                                                                     
 
-##[comb.async.map](./comb_async.html#.map)
+## [comb.async.map](./comb_async.html#.map)
 
  Loops through the results of an promise resolving with the return value of the iterator function.     
  The promise can return an array or just a single item.                                                
@@ -466,7 +466,7 @@ comb.async.forEach(asyncArr(), function(item, index){
  });                                                                                                   
  ```                                                                                                                                                                                                                                                                                                                             
 
-##[comb.async.filter](./comb_async.html#.filter)
+## [comb.async.filter](./comb_async.html#.filter)
 
 Loops through the results of an promise resolving with the filtered array.
 The promise can return an array or just a single item.                    
@@ -499,7 +499,7 @@ comb.async.filter(asyncArr(), function(item, index){
     console.log(myNewArr); //[1,3,5];                                      
 })                                                                        
 ```                                                                       
-##[comb.async.every](./comb_async.html#.every)
+## [comb.async.every](./comb_async.html#.every)
 
 Loops through the results of an promise resolving with true if every item passed, false otherwise.   
 The promise can return an array or just a single item.                                               
@@ -533,7 +533,7 @@ comb.async.every(asyncArr(), function(item, index){
 })                                                                                                   
 ```                                                                                                  
 
-##[comb.async.some](./comb_async.html#.some)
+## [comb.async.some](./comb_async.html#.some)
 
 Loops through the results of an promise resolving with true if some items passed, false otherwise.      
 The promise can return an array or just a single item.                                                  
@@ -567,7 +567,7 @@ comb.async.some(asyncArr(), function(item, index){
 })                                                                                                      
 ```  
 
-##[comb.async.pluck](./comb_async.html#.pluck)
+## [comb.async.pluck](./comb_async.html#.pluck)
 
 Async version of [comb.array.pluck](./comb_array.html#.pluck)
                                                                                                                              

--- a/docs-md/utilities.md
+++ b/docs-md/utilities.md
@@ -1,8 +1,8 @@
-#Common Utilities
+# Common Utilities
 
 `comb` includes a lot of function that are used commonly when developing application. Here we'll go over a few of the most commonly used ones.
 
-##is* functions
+## is* functions
 
 `comb` includes a number of `is` function to test if something is of the type.
 
@@ -23,9 +23,9 @@
 * [isRegExp](./comb.html#.isRegExp)
 * [isString](./comb.html#.isString)
 
-##[String utilities](./comb_string.html)
+## [String utilities](./comb_string.html)
 
-###[format](./comb_string.html#.format)
+### [format](./comb_string.html#.format)
 
 Formats a string with the specified format.                                  
                                                                                
@@ -86,7 +86,7 @@ comb.string.format("{[-s10]apple}, {[%#10]orange}, {[10]banana} and {[-10]waterm
 * Date Options `%[format]D` or `%[format]Z`. See [comb.date.format](./comb_date.html#.format) for formatting options.   
                                                                   
 
-###[style](./comb_string.html#.style)
+### [style](./comb_string.html#.style)
 
 Styles a string for terminal output.
 
@@ -123,16 +123,16 @@ The style options include
 * grey
 * black
 
-###Others
+### Others
 * [pad](./comb_string.html#.pad)
 * [toArray](./comb_string.html#.pad)
 * [truncate](./comb_string.html#.pad)
 * [multiply](./comb_string.html#.pad)
 
                                                                                            
-##[Array utilities](./comb_array.html)
+## [Array utilities](./comb_array.html)
 
-###[avg](./comb_array.html#.avg)
+### [avg](./comb_array.html#.avg)
 
 Averages an array of numbers.
 
@@ -140,7 +140,7 @@ Averages an array of numbers.
 comb.array.avg([1,2,3]); //2
 ```
 
-###[compact](./comb_array.html#.compact)
+### [compact](./comb_array.html#.compact)
 
 Compacts an array removing `null` or `undefined` objects from the array.
 
@@ -150,7 +150,7 @@ comb.array.compact([1,null,null,x,2]) => [1,2]
 comb.array.compact([1,2]) => [1,2]
 ```
 
-###[difference](./comb_array.html#.difference)
+### [difference](./comb_array.html#.difference)
 
 Finds the difference of the two arrays.
 
@@ -159,7 +159,7 @@ comb.array.difference([1,2,3], [2,3]); //[1]
 comb.array.difference(["a","b",3], [3]); //["a","b"]
 ```
 
-###[flatten](./comb_array.html#.flatten)
+### [flatten](./comb_array.html#.flatten)
 
 Flatten multiple arrays into a single array
 
@@ -168,7 +168,7 @@ comb.array.flatten([1,2], [2,3], [3,4]) => [1,2,2,3,3,4]
 comb.array.flatten([1,"A"], [2,"B"], [3,"C"]) => [1,"A",2,"B",3,"C"]
 ```
 
-###[intersect](./comb_array.html#.compact)
+### [intersect](./comb_array.html#.compact)
 
 Finds the intersection of arrays.
 
@@ -180,7 +180,7 @@ comb.array.intersect([1,2,3,4,5], [1,2,3,4,5], [1,2,3]) => [1,2,3]
 comb.array.intersect([[1,2,3,4,5],[1,2,3,4,5],[1,2,3]]) => [1,2,3]
 ```
 
-###[max](./comb_array.html#.compact)
+### [max](./comb_array.html#.compact)
 
 Finds that max value of an array. If a second argument is provided and it is a function it will be used as a comparator function. If the second argument is a string then it will be used as a property look up on each item.
 
@@ -192,7 +192,7 @@ comb.array.max([{a : 1}, {a : 2}, {a : -2}], function(a,b){
 
 ```
 
-###[min](./comb_array.html#.compact)
+### [min](./comb_array.html#.compact)
 
 Finds that min value of an array. If a second argument is provided and it is a function it will be used as a comparator function. If the second argument is a string then it will be used as a property look up on each item.
 
@@ -203,7 +203,7 @@ comb.array.min([{a : 1}, {a : 2}, {a : -2}], function(a,b){
 }); //{a : -2}
 ```
 
-###[sort](./comb_array.html#.compact)
+### [sort](./comb_array.html#.compact)
 
 
 Allows the sorting of an array based on a property name instead. This can also act as a sort that does not change the original array. **NOTE: this does not change the original array!**
@@ -213,7 +213,7 @@ comb.array.sort([{a : 1}, {a : 2}, {a : -2}], "a"); //[{a : -2}, {a : 1}, {a : 2
 ```
         
 
-###[removeDuplicates](./comb_array.html#.removeDuplicates)
+### [removeDuplicates](./comb_array.html#.removeDuplicates)
 
 Removes duplicates from an array.
 
@@ -222,7 +222,7 @@ comb.array.removeDuplicates([1,1,1]) => [1]
 comb.array.removeDuplicates([1,2,3,2]) => [1,2,3]
 ```
 
-###[sum](./comb_array.html#.sum)
+### [sum](./comb_array.html#.sum)
 
 Finds the sum of an array
 
@@ -230,7 +230,7 @@ Finds the sum of an array
 comb.array.sum([1,2,3]) => 6
 ```
 
-###[toArray](./comb_array.html#.toArray)
+### [toArray](./comb_array.html#.toArray)
 
 Converts anything to an array. Useful if you want to covert a hash into an array.
 
@@ -241,7 +241,7 @@ comb.array.toArray(["a"]) =>  ["a"];
 comb.array.toArray() => [];
 comb.array.toArray("a", {a : "b"}) => ["a", ["a", "b"]];
 ```
-###[union](./comb_array.html#.union)
+### [union](./comb_array.html#.union)
 
 Finds the union of two arrays
 
@@ -250,7 +250,7 @@ comb.array.union(['a','b','c'], ['b','c', 'd']) => ["a", "b", "c", "d"]
 comb.array.union(["a"], ["b"], ["c"], ["d"], ["c"]) => ["a", "b", "c", "d"]
 ```
 
-###[zip](./comb_array.html#.zip)
+### [zip](./comb_array.html#.zip)
 
 Zips multiple arrays into a single array.
 
@@ -267,9 +267,9 @@ comb.array.zip(a, [1,2], [8]) => [[4,1,8],[5,2,null],[6,null,null]]
 
 
 
-##[Number utilities](./comb_number.html)
+## [Number utilities](./comb_number.html)
 
-###[round](./comb_number.html#.round)
+### [round](./comb_number.html#.round)
 Rounds a number to the specified places.
 
 ```
@@ -279,7 +279,7 @@ comb.number.round(10.0009, 3); //10.001
 comb.number.round(10.0009, 2); //10
 comb.number.round(10.0009, 3); //10.001
 ```
-###[roundCeil](./comb_number.html#.roundCel)
+### [roundCeil](./comb_number.html#.roundCel)
 
 Rounds a number to the specified places, rounding up.
 
@@ -292,9 +292,9 @@ comb.number.roundCeil(10.0005, 3); //10.001
 comb.number.roundCeil(10.0002, 2); //10.01
 ```
 
-##[Date utilities](./comb_date.html)
+## [Date utilities](./comb_date.html)
 
-###[add](./comb_date.html#.add)
+### [add](./comb_date.html#.add)
 
 Adds a specified interval and amount to a date
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
