### PR TITLE
Fix typo preventing comb.date.format(EEE) from properly returning an …

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+* Fixed issue in comb.date.format not correctly returning an abbreviated weekday name for "EEE"
+* Removed periods from abbreviated month name list. Punctuation should be added in the format string to be more flexible.
+
 # 1.1.0
 
 * Porting 1.1.0 code back to 1.0.1 so we don't have to updated all the dependent apps.

--- a/lib/base/date/index.js
+++ b/lib/base/date/index.js
@@ -24,7 +24,7 @@ function getString() {
 
 var floor = Math.floor, round = Math.round, min = Math.min, pow = Math.pow, ceil = Math.ceil, abs = Math.abs;
 var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-var monthAbbr = ["Jan.", "Feb.", "Mar.", "Apr.", "May.", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec."];
+var monthAbbr = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 var monthLetter = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 var dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 var dayAbbr = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -691,7 +691,7 @@ comb.date = {
                     s = day + 1;
                     pad = true;
                 } else {
-                    s = (l === -3 ? dayAbbr : dayNames)[day];
+                    s = (l === 3 ? dayAbbr : dayNames)[day];
                 }
             } else if (c === 'a') {
                 s = (hour < 12) ? 'AM' : 'PM';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "comb",
     "description": "A framework for node",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "keywords": [
         "OO",
         "Object Oriented",

--- a/test/base/date.test.js
+++ b/test/base/date.test.js
@@ -190,6 +190,10 @@ it.describe("comb.date", function (it) {
             assert.equal(date.format("E", true), "6");
         });
 
+        it.should("EEE to Fri ", function () {
+            assert.equal(date.format("EEE", true), "Fri")
+        });
+
         it.should("h:m a to 5:55 AM ", function () {
             assert.equal(date.format("h:m a", true), ((date.getUTCHours() % 12) || 12) + ":55 AM");
         });


### PR DESCRIPTION
…abbreviated weekday name

Removed '.' from abbreviated month name list to allow for flexibility in
punctuation, which should be added in the format string.

Updated to 1.2.0 due to the change in the abbreviations.