### PR TITLE
Update travis to test node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ language: node_js
 node_js:
   - "4"
   - "5"
-  - "stable"
+  - "6"
+  - "8"


### PR DESCRIPTION
Add node 8 as well as it is next LTS after 6. It would be good to know that comb works with higher node versions and can give ourselves an upgrade path.